### PR TITLE
Convert atom-sorter to TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "publish": "npm run build-lerna && npm run test && lerna publish -y --no-verify-access",
     "test": "npm run test-only && npm run eslint && npm run prettier",
     "test-only": "npm run build-lerna && vitest --run --test-timeout=30000 --globals",
-    "tsc": "tsc --build"
+    "tsc": "tsc --build",
+    "tsc-watch": "tsc --build --watch"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.24.7",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.14.10",
-    "@vitest/coverage-v8": "^1.6.0",
+    "@vitest/coverage-v8": "^2.0.1",
     "benchmark": "^2.1.4",
     "cheminfo-build": "^1.2.0",
     "documentation": "^14.0.3",
@@ -47,8 +47,7 @@
     "lerna": "^8.1.6",
     "msw": "^2.3.1",
     "prettier": "^3.3.2",
-    "rimraf": "^5.0.8",
     "typescript": "^5.5.3",
-    "vitest": "^1.6.0"
+    "vitest": "^2.0.1"
   }
 }

--- a/packages/atom-sorter/package.json
+++ b/packages/atom-sorter/package.json
@@ -3,10 +3,9 @@
   "version": "2.1.1",
   "description": "Callback allowing to sort chemical elements (atoms) in Hill order",
   "main": "lib/src/index.js",
-  "module": "src/index.js",
   "files": [
-    "src",
-    "lib"
+    "lib",
+    "src"
   ],
   "repository": {
     "type": "git",

--- a/packages/atom-sorter/src/__tests__/index.test.ts
+++ b/packages/atom-sorter/src/__tests__/index.test.ts
@@ -1,3 +1,5 @@
+import { test, expect } from 'vitest';
+
 import { atomSorter } from '..';
 
 test('atom-sorter test', () => {
@@ -9,13 +11,13 @@ test('atom-sorter test', () => {
 });
 
 test('sort an array', () => {
-  let atoms = ['H', 'Cl', 'C', 'O', 'N', 'Br'];
+  const atoms = ['H', 'Cl', 'C', 'O', 'N', 'Br'];
   atoms.sort((a, b) => atomSorter(a, b));
   expect(atoms).toStrictEqual(['C', 'H', 'Br', 'Cl', 'N', 'O']);
 });
 
 test('sort an array HCl', () => {
-  let atoms = ['Cl', 'H'];
+  const atoms = ['Cl', 'H'];
   atoms.sort((a, b) => atomSorter(a, b));
   expect(atoms).toStrictEqual(['H', 'Cl']);
 });

--- a/packages/atom-sorter/src/index.ts
+++ b/packages/atom-sorter/src/index.ts
@@ -1,12 +1,11 @@
 /**
  * Implementation of the Hill system for sorting atoms
  * https://en.wikipedia.org/wiki/Chemical_formula#Hill_system
- * @param {string} a - first atom to compare
- * @param {string} b - second atom to compare
- * @returns
+ * @param a - first atom to compare
+ * @param b - second atom to compare
+ * @returns A value suitable for use in Array.prototype.sort.
  */
-
-export function atomSorter(a, b) {
+export function atomSorter(a: string, b: string): 0 | -1 | 1 {
   if (a === b) return 0;
   if (a === 'C') return -1;
   if (b === 'C') return 1;


### PR DESCRIPTION
- **refactor: rewrite atom-sorter in TypeScript**
- **chore: update Vitest to v2**
