### PR TITLE
isotopologues

### DIFF
--- a/packages/isotopic-distribution/src/IsotopicDistribution.js
+++ b/packages/isotopic-distribution/src/IsotopicDistribution.js
@@ -97,7 +97,7 @@ export class IsotopicDistribution {
         {
           x: 0,
           y: 1,
-          composition: this.fwhm === MINIMAL_FWHM ? {} : undefined,
+          composition: this.fwhm === MINIMAL_FWHM ? {} : undefined, // should we calculate composition in isotopes of each peak
         },
       ]);
       let charge = part.ms.charge;

--- a/packages/isotopic-distribution/src/IsotopicDistribution.types.ts
+++ b/packages/isotopic-distribution/src/IsotopicDistribution.types.ts
@@ -21,6 +21,8 @@ export interface IsotopicDistributionOptions {
   ionizations?: string;
   /**
    * Amount of Dalton under which 2 peaks are joined.
+   * If the fwhm is smaller than 1e-8 we will calculate the composition in isotopes for each peak and add the corresponding property.
+   * This allows to annotate the isotopic composition at the level of each peak.
    * @default 0.01
    */
   fwhm?: number;

--- a/packages/isotopic-distribution/src/__tests__/isotopicDistribution.test.js
+++ b/packages/isotopic-distribution/src/__tests__/isotopicDistribution.test.js
@@ -25,6 +25,21 @@ describe('test isotopicDistribution', () => {
     expect(distribution.array[0].x).toBe(12);
   });
 
+  it('create distribution of [13C]', () => {
+    const isotopicDistribution = new IsotopicDistribution('[13C]', {
+      fwhm: 1e-8,
+    });
+    const peaks = isotopicDistribution.getXY();
+    expect(peaks).toBeDeepCloseTo({
+      x: [13.00335483507],
+      y: [100],
+      composition: [{ '13C': 1 }],
+      label: ['¹³C'],
+      shortComposition: [{ '13C': 1 }],
+      shortLabel: ['¹³C'],
+    });
+  });
+
   it('create distribution of C Ag+', () => {
     let isotopicDistribution = new IsotopicDistribution('C', {
       ionizations: 'Ag+',

--- a/packages/mf-parser/src/__tests__/getIsotopesInfo.test.js
+++ b/packages/mf-parser/src/__tests__/getIsotopesInfo.test.js
@@ -34,5 +34,9 @@ test('getIsotopesInfo from (CH3(+))2', () => {
 test('getIsotopesInfo from [13C]', () => {
   let mf = new MF('[12C]');
   let info = mf.getIsotopesInfo();
-  expect(info.isotopes[0]).toStrictEqual({ atom: 'C', number: 1, distribution: [{ x: 12, y: 1 }] })
+  expect(info.isotopes[0]).toStrictEqual({
+    atom: 'C',
+    number: 1,
+    distribution: [{ x: 12, y: 1 }],
+  });
 });

--- a/packages/mf-parser/src/__tests__/getIsotopesInfo.test.js
+++ b/packages/mf-parser/src/__tests__/getIsotopesInfo.test.js
@@ -30,3 +30,9 @@ test('getIsotopesInfo from (CH3(+))2', () => {
   let info = mf.getIsotopesInfo();
   expect(info.charge).toBe(2);
 });
+
+test('getIsotopesInfo from [13C]', () => {
+  let mf = new MF('[12C]');
+  let info = mf.getIsotopesInfo();
+  expect(info.isotopes[0]).toStrictEqual({ atom: 'C', number: 1, distribution: [{ x: 12, y: 1 }] })
+});

--- a/packages/mf-parser/src/util/getIsotopesInfo.js
+++ b/packages/mf-parser/src/util/getIsotopesInfo.js
@@ -42,7 +42,7 @@ function getProcessedPart(part) {
           );
         }
         result.isotopes.push({
-          atom: `[${line.value.isotope}${line.value.atom}]`,
+          atom: line.value.atom,
           number: line.multiplier,
           distribution: [{ x: isotope.mass, y: 1 }],
         });
@@ -58,7 +58,7 @@ function getProcessedPart(part) {
             line.value.ratio,
           );
           result.isotopes.push({
-            atom: `${line.value.atom}{${line.value.ratio.join(',')}}`,
+            atom: line.value.atom,
             number: line.multiplier,
             distribution,
           });


### PR DESCRIPTION
- **fix(mf-parser): getIsotopesInfo set correctly in the atom property the atom and not the isotope or enriched isotope**
- **fix(isotopic-distribution): deal correctly with isotopologues in case of non natural isotopic distribution**
