### PR TITLE
fix(mf-parser): package.json exposes only main

### DIFF
--- a/packages/mf-parser/package.json
+++ b/packages/mf-parser/package.json
@@ -3,7 +3,6 @@
   "version": "3.2.7",
   "description": "Parse a molecular formula",
   "main": "lib/src/index.js",
-  "module": "src/index.js",
   "files": [
     "src",
     "lib"

--- a/packages/mf-parser/src/index.js
+++ b/packages/mf-parser/src/index.js
@@ -11,6 +11,7 @@ export * from './MF';
 export * from './parseToHtml.js';
 
 // types
+export { AtomsMap } from './util/partToAtoms.types';
 export { IsotopesInfo } from './util/getIsotopesInfo.types';
 export {
   PartInfo,

--- a/packages/mf-parser/src/index.ts
+++ b/packages/mf-parser/src/index.ts
@@ -11,9 +11,9 @@ export * from './MF';
 export * from './parseToHtml.js';
 
 // types
-export { AtomsMap } from './util/partToAtoms.types';
-export { IsotopesInfo } from './util/getIsotopesInfo.types';
-export {
+export type { AtomsMap } from './util/partToAtoms.types';
+export type { IsotopesInfo } from './util/getIsotopesInfo.types';
+export type {
   PartInfo,
   PartInfoWithParts,
   GetInfoOptions,

--- a/packages/mf-parser/src/parseToHtml.js
+++ b/packages/mf-parser/src/parseToHtml.js
@@ -1,4 +1,6 @@
-import { parse, toDisplay, toHtml } from './index.js';
+import { parse } from './parse.js';
+import { toDisplay } from './util/toDisplay.js';
+import { toHtml } from './util/toHtml.js';
 
 /**
  * Parse a molecular formula and converts it to an HTML code

--- a/packages/mf-parser/src/util/getInfo.types.ts
+++ b/packages/mf-parser/src/util/getInfo.types.ts
@@ -1,4 +1,4 @@
-import type { AtomsMap } from './partToAtoms';
+import type { AtomsMap } from './partToAtoms.types';
 
 type ImpossibleCustomNames =
   | 'mass'

--- a/packages/mf-parser/src/util/partToAtoms.js
+++ b/packages/mf-parser/src/util/partToAtoms.js
@@ -1,6 +1,6 @@
 import { Kind } from '../Kind.js';
 
-/** @typedef {Record<string, number>} AtomsMap */
+/** @typedef {import('./partToAtoms.types').AtomsMap} AtomsMap */
 
 /**
  * Convert a MF part to a map of atoms

--- a/packages/mf-parser/src/util/partToAtoms.types.ts
+++ b/packages/mf-parser/src/util/partToAtoms.types.ts
@@ -1,0 +1,1 @@
+export type AtomsMap = Record<string, number>;


### PR DESCRIPTION
put AtomsMap type in a dedicated ts file and export it

Refs: https://github.com/zakodium/peak-by-peak/pull/150