### PR TITLE
test: fix tests on Node.js 24

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,3 +10,5 @@ jobs:
   nodejs:
     # Documentation: https://github.com/zakodium/workflows#nodejs-ci
     uses: zakodium/workflows/.github/workflows/nodejs.yml@nodejs-v1
+    with:
+      disable-test-package: true

--- a/packages/mass-fragmentation/src/__tests__/getFragmentationSVG.test.js
+++ b/packages/mass-fragmentation/src/__tests__/getFragmentationSVG.test.js
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import OCL, { Molecule } from 'openchemlib';
 import { expect, test } from 'vitest';
 

--- a/packages/mf-parser/src/__tests__/MF.test.ts
+++ b/packages/mf-parser/src/__tests__/MF.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, expectTypeOf } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { MF } from '..';
 
@@ -553,8 +553,8 @@ describe('MF', () => {
   it('Types getInfo default shape', () => {
     const mf = new MF('C10#1H20');
     const info = mf.getInfo();
-    expectTypeOf(info).toMatchTypeOf<{ monoisotopicMass: number }>();
-    expectTypeOf(info).not.toMatchTypeOf<{ em: number }>();
+    expectTypeOf(info).toExtend<{ monoisotopicMass: number }>();
+    expectTypeOf(info).not.toExtend<{ em: number }>();
     expect(info).toStrictEqual({
       mass: 140.26617404846803,
       monoisotopicMass: 140.1565006446,
@@ -569,8 +569,8 @@ describe('MF', () => {
   it('Types getInfo custom shape', () => {
     const mf = new MF('C10#1H20');
     const info = mf.getInfo({ emFieldName: 'em' as const });
-    expectTypeOf(info).toMatchTypeOf<{ em: number }>();
-    expectTypeOf(info).not.toMatchTypeOf<{ monoisotopicMass: number }>();
+    expectTypeOf(info).toExtend<{ em: number }>();
+    expectTypeOf(info).not.toExtend<{ monoisotopicMass: number }>();
     expect(info).toStrictEqual({
       mass: 140.26617404846803,
       em: 140.1565006446,

--- a/packages/octochemdb/src/utils/__tests__/postFetchJSON.test.js
+++ b/packages/octochemdb/src/utils/__tests__/postFetchJSON.test.js
@@ -4,7 +4,7 @@ import { postFetchJSON } from '../postFetchJSON.js';
 
 test('postFetchJSON', async () => {
   const patents = await postFetchJSON(
-    'https://octochemdb.epfl.ch/patents/v1/ids',
+    'https://octochemdb.cheminfo.org/patents/v1/ids',
     { ids: ['EP-2078065-A2, EP-1293521-A2'] },
   );
   expect(patents.data.length).toBe(2);

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -2,7 +2,6 @@ import { coverageConfigDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    environment: 'jsdom',
     coverage: {
       exclude: [
         'benchmark/**',


### PR DESCRIPTION
- Only use jsdom in the test that needs it.
- Use non-deprecated type test API
- Disable `test-package` job. It's not designed for monorepos.
